### PR TITLE
Fix encrypted authentication

### DIFF
--- a/src/client/socket_client.cpp
+++ b/src/client/socket_client.cpp
@@ -221,14 +221,14 @@ void Client::handleJsonMessage(const std::string& jsonStr, WINDOW* outputWin) {
         std::string enc_username = rsa.encrypt(username, rsa.publicKeyB);
         std::string enc_password = rsa.encrypt(password, rsa.publicKeyB);
         if (authType == 1) {
-            // Create user
-            json response = json{{"type", "verify"}, {"username", username}, {"password", password}};
+            // Verify existing user
+            json response = json{{"type", "verify"}, {"username", enc_username}, {"password", enc_password}};
             sendMessage(response);
         } else if (authType == 2) {
-            // Verify user
+            // Create a new user
             json response = json{{"type", "create"}, {"username", enc_username}, {"password", enc_password}};
             sendMessage(response);
-            authType = 1;
+            authType = 1; // Next prompt should attempt verification
         }
     }
     else {

--- a/src/server/socket_server.cpp
+++ b/src/server/socket_server.cpp
@@ -321,7 +321,10 @@ bool Server::verifyUser(std::string& user) {
     auto j = json::parse(user);
     std::string username = j["username"];
     std::string password = j["password"];
-    
+    // Decrypt credentials received from the client
+    username = this->rsa.decrypt(username);
+    password = this->rsa.decrypt(password);
+
     // Verify the user using the user handler
     UserHandler userHandler("assets/users.txt");
     if (userHandler.VerifyUser(username, password)) {


### PR DESCRIPTION
## Summary
- fix client authentication message
- decrypt credentials on server verification

## Testing
- `make -C tests all` *(fails: cryptopp headers missing)*

------
https://chatgpt.com/codex/tasks/task_e_684339777edc83238fc8c32ea4c134f6